### PR TITLE
Fix timezone offsets for getting hourly weather

### DIFF
--- a/Service/Forecast.php
+++ b/Service/Forecast.php
@@ -103,7 +103,9 @@ class Forecast
   {
     $forecastForDay = $this->getForDay($latitude, $longitude, $timestamp);
 
-    $hour = intval(date('G', $timestamp));
+    $forecastTz = $forecastForDay->getLocation()->getTimezone();
+
+    $hour = \DateTime::createFromFormat('U', $timestamp)->setTimezone(new \DateTimeZone($forecastTz))->format('G');
 
     return $forecastForDay->getHour($hour);
   }


### PR DESCRIPTION
See what you want todo with this fix, however it fixes the following:

When currently fetching day-data we receive a array with hourly data from forecast.io. This array starts with the 00:00 hour of the local timezone of the given coordinates. Because the WeatherForecastForDay class simply iterates on this hourly-data array and converts it to a array of WeatherForecastForHour instances we should keep in mind the array is purely build on hour-by-hour data in the local timezone of the coordinates.

Currently on the getForHour() function in the Forecast class it simply converts a epoch (which is UTC as always) to a hour number using:

``` PHP
$hour = intval(date('G', $timestamp));
```

Which returns wrong results in any timezone beside UTC.

What i did is simply applied a small method which takes the timezone out of the API response and applies it to the $timestamp before formatting a 'hour' integer out of it.
